### PR TITLE
Tail rec `traverse` and `sequence` + changes

### DIFF
--- a/src/Async.fs
+++ b/src/Async.fs
@@ -50,34 +50,6 @@ module Async =
 
     let andMap (asyncOp: Async<'a>) (f: Async<'a -> 'b>) : Async<'b> = map2 (|>) asyncOp f
 
-    let internal mapM (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> =
-        List.foldBack
-            (fun head tail ->
-                f head
-                >>= (fun head' ->
-                    tail
-                    >>= (fun tail' -> singleton (cons head' tail'))))
-            asyncOps
-            (singleton [])
-
-    let traverse (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> =
-        List.foldBack (fun head tail -> cons <!> f head <*> tail) asyncOps (singleton [])
-
-    let traverseParallel (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> =
-        List.foldBack (fun head tail -> cons <!> f head <&> tail) asyncOps (singleton [])
-
-    let sequence (asyncOps: Async<'a> list) : Async<'a list> = mapM id asyncOps
-
-    let sequenceA (asyncOps: Async<'a> list) : Async<'a list> = traverse id asyncOps
-
-    let sequenceAParallel (asyncOps: Async<'a> list) : Async<'a list> = traverseParallel id asyncOps
-
-    let parallel' (asyncOps: Async<'a> list) : Async<'a list> =
-        async {
-            let! resArray = Async.Parallel asyncOps
-            return List.ofArray resArray
-        }
-
     let zip (asyncOp1: Async<'a>) (asyncOp2: Async<'b>) : Async<'a * 'b> =
         (fun a b -> a, b) <!> asyncOp1 <*> asyncOp2
 

--- a/src/AsyncOption.fs
+++ b/src/AsyncOption.fs
@@ -29,19 +29,6 @@ module AsyncOptionOperators =
             | None -> Async.singleton None)
             asyncOption
 
-    let inline (>=>) (f: 'a -> Async<'b option>) (g: 'b -> Async<'c option>) : 'a -> Async<'c option> =
-        fun x ->
-            async {
-                let! f' = f x
-
-                let! g' =
-                    match f' with
-                    | Some thing -> g thing
-                    | None -> Async.singleton None
-
-                return g'
-            }
-
     let inline (<|>) (asyncOption1: Async<'a option>) (asyncOption2: Async<'a option>) : Async<'a Option> =
         Async.map2 Option.alternative asyncOption1 asyncOption2
 

--- a/src/AsyncOption.fs
+++ b/src/AsyncOption.fs
@@ -62,7 +62,7 @@ module AsyncOption =
 
     let andMap (asyncOption: AsyncOption<'a>) (f: AsyncOption<'a -> 'b>) : AsyncOption<'b> = map2 (|>) asyncOption f
 
-    let rec private traverser f folder state xs =
+    let rec private traverser (f: 'a -> AsyncOption<'b>) folder state xs =
         match xs with
         | [] -> List.rev <!> state
         | head :: tail ->

--- a/src/AsyncOption.fs
+++ b/src/AsyncOption.fs
@@ -95,10 +95,10 @@ module AsyncOption =
         traverser f folder (singleton []) asyncOptions
 
     let traverse (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
-        traverser f (fun head tail -> (fun h t -> h :: t) <!> f head <*> tail) (singleton []) asyncOptions
+        traverser f (fun head tail -> cons <!> f head <*> tail) (singleton []) asyncOptions
 
     let traverseParallel (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
-        traverser f (fun head tail -> (fun h t -> h :: t) <!> f head <&> tail) (singleton []) asyncOptions
+        traverser f (fun head tail -> cons <!> f head <&> tail) (singleton []) asyncOptions
 
     let sequence (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> = mapM id asyncOptions
 

--- a/src/AsyncOption.fs
+++ b/src/AsyncOption.fs
@@ -75,38 +75,36 @@ module AsyncOption =
 
     let andMap (asyncOption: AsyncOption<'a>) (f: AsyncOption<'a -> 'b>) : AsyncOption<'b> = map2 (|>) asyncOption f
 
-    let compose (f: 'a -> Async<'b option>) (g: 'b -> Async<'c option>) : 'a -> Async<'c option> = f >=> g
+    let rec private traverser f folder state xs =
+        match xs with
+        | [] -> List.rev <!> state
+        | head :: tail ->
+            async {
+                match! folder head state with
+                | Some _ as this -> return! traverser f folder (Async.singleton this) tail
+                | None as this -> return this
+            }
 
-    let internal traverseM (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
-        List.foldBack
-            (fun head tail ->
-                f head
-                >>= (fun head' ->
+    let mapM (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
+        let folder head tail =
+            f head
+            >>= fun head' ->
                     tail
-                    >>= (fun tail' -> singleton ((fun h t -> h :: t) head' tail'))))
-            asyncOptions
-            (singleton [])
+                    >>= fun tail' -> singleton <| cons head' tail'
 
-    let internal traverseA (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
-        List.foldBack (fun head tail -> (fun h t -> h :: t) <!> f head <*> tail) asyncOptions (singleton [])
+        traverser f folder (singleton []) asyncOptions
 
-    let internal traverseAParallel (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
-        List.foldBack (fun head tail -> (fun h t -> h :: t) <!> f head <&> tail) asyncOptions (singleton [])
+    let traverse (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
+        traverser f (fun head tail -> (fun h t -> h :: t) <!> f head <*> tail) (singleton []) asyncOptions
 
-    let internal sequenceM (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> = traverseM id asyncOptions
+    let traverseParallel (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
+        traverser f (fun head tail -> (fun h t -> h :: t) <!> f head <&> tail) (singleton []) asyncOptions
 
-    let internal sequenceA (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> = traverseA id asyncOptions
+    let sequence (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> = mapM id asyncOptions
 
-    let internal sequenceAParallel (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> =
-        traverseAParallel id asyncOptions
+    let sequenceA (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> = traverse id asyncOptions
 
-    let sequence (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> = sequenceM asyncOptions
-
-    let parallel' (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> =
-        async {
-            let! array = Async.Parallel asyncOptions
-            return Option.sequence (List.ofArray array)
-        }
+    let sequenceAParallel (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> = traverseParallel id asyncOptions
 
     let zip (asyncOption1: AsyncOption<'a>) (asyncOption2: AsyncOption<'b>) : Async<('a * 'b) option> =
         (fun a b -> a, b) <!> asyncOption1

--- a/src/AsyncResult.fs
+++ b/src/AsyncResult.fs
@@ -33,18 +33,6 @@ module AsyncResultOperators =
             | Error error -> Async.singleton (Error error))
             asyncResult
 
-    let inline (>=>) (f: 'a -> Async<Result<'b, 'e>>) (g: 'b -> Async<Result<'c, 'e>>) : 'a -> Async<Result<'c, 'e>> =
-        fun x ->
-            async {
-                let! f' = f x
-
-                let! g' =
-                    match f' with
-                    | Ok ok -> g ok
-                    | Error e -> Async.singleton (Error e)
-
-                return g'
-            }
 
 namespace FSharp.Prelude
 

--- a/src/AsyncResult.fs
+++ b/src/AsyncResult.fs
@@ -81,7 +81,7 @@ module AsyncResult =
     let bimap (f: 'a -> 'b) (g: 'e1 -> 'e2) (asyncResult: AsyncResult<'a, 'e1>) : AsyncResult<'b, 'e2> =
         (map f >> mapError g) asyncResult
 
-    let rec private traverser f folder state xs =
+    let rec private traverser (f: 'a -> AsyncResult<'b, 'e>) folder state xs =
         match xs with
         | [] -> List.rev <!> state
         | head :: tail ->

--- a/src/AsyncResult.fs
+++ b/src/AsyncResult.fs
@@ -48,7 +48,6 @@ module AsyncResultOperators =
 
 namespace FSharp.Prelude
 
-open FSharp.Prelude
 open FSharp.Prelude.Operators.AsyncResult
 open System.Threading.Tasks
 
@@ -107,9 +106,9 @@ module AsyncResult =
     let mapM (f: 'a -> AsyncResult<'b, 'e>) (asyncResults: 'a list) : AsyncResult<'b list, 'e> =
         let folder head tail =
             f head
-            >>= (fun head' ->
-                tail
-                >>= (fun tail' -> singleton <| cons head' tail'))
+            >>= fun head' ->
+                    tail
+                    >>= fun tail' -> singleton <| cons head' tail'
 
         traverser f folder (singleton []) asyncResults
 

--- a/src/AsyncResultOption.fs
+++ b/src/AsyncResultOption.fs
@@ -35,22 +35,6 @@ module AsyncResultOptionOperators =
             | None -> AsyncResult.singleton None)
             asyncResultOption
 
-    let inline (>=>)
-        (f: 'a -> AsyncResult<'b option, 'e>)
-        (g: 'b -> AsyncResult<'c option, 'e>)
-        : 'a -> AsyncResult<'c option, 'e> =
-        fun x ->
-            asyncResult {
-                let! f' = f x
-
-                let! g' =
-                    match f' with
-                    | Some thing -> g thing
-                    | None -> AsyncResult.singleton None
-
-                return g'
-            }
-
     let inline (<|>)
         (asyncOption1: AsyncResult<'a option, 'e>)
         (asyncOption2: AsyncResult<'a option, 'e>)

--- a/src/AsyncResultOption.fs
+++ b/src/AsyncResultOption.fs
@@ -104,7 +104,7 @@ module AsyncResultOption =
         : AsyncResultOption<'b, 'e2> =
         (map f >> mapError g) asyncResultOption
 
-    let rec private traverser f folder state xs =
+    let rec private traverser (f: 'a -> AsyncResultOption<'b, 'e>) folder state xs =
         match xs with
         | [] -> List.rev <!> state
         | head :: tail ->

--- a/src/AsyncResultOption.fs
+++ b/src/AsyncResultOption.fs
@@ -120,53 +120,44 @@ module AsyncResultOption =
         : AsyncResultOption<'b, 'e2> =
         (map f >> mapError g) asyncResultOption
 
-    let compose
-        (f: 'a -> AsyncResultOption<'b, 'e>)
-        (g: 'b -> AsyncResultOption<'c, 'e>)
-        : 'a -> AsyncResultOption<'c, 'e> =
-        f >=> g
+    let rec private traverser f folder state xs =
+        match xs with
+        | [] -> List.rev <!> state
+        | head :: tail ->
+            async {
+                match! folder head state with
+                | Ok _ as this -> return! traverser f folder (Async.singleton this) tail
+                | Error _ as this -> return this
+            }
 
-    let internal traverseM
-        (f: 'a -> AsyncResultOption<'b, 'e>)
-        (asyncResultOptions: 'a list)
-        : AsyncResultOption<'b list, 'e> =
-        List.foldBack
-            (fun head tail ->
-                f head
-                >>= (fun head' ->
+    let mapM (f: 'a -> AsyncResultOption<'b, 'e>) (asyncResultOptions: 'a list) : AsyncResultOption<'b list, 'e> =
+        let folder head tail =
+            f head
+            >>= fun head' ->
                     tail
-                    >>= (fun tail' -> singleton ((fun h t -> h :: t) head' tail'))))
-            asyncResultOptions
-            (singleton [])
+                    >>= fun tail' -> singleton <| cons head' tail'
 
-    let internal traverseA
+        traverser f folder (singleton []) asyncResultOptions
+
+    let traverse (f: 'a -> AsyncResultOption<'b, 'e>) (asyncResultOptions: 'a list) : AsyncResultOption<'b list, 'e> =
+        traverser f (fun head tail -> cons <!> f head <*> tail) (singleton []) asyncResultOptions
+
+    let traverseParallel
         (f: 'a -> AsyncResultOption<'b, 'e>)
         (asyncResultOptions: 'a list)
         : AsyncResultOption<'b list, 'e> =
-        List.foldBack (fun head tail -> (fun h t -> h :: t) <!> f head <*> tail) asyncResultOptions (singleton [])
+        traverser f (fun head tail -> cons <!> f head <&> tail) (singleton []) asyncResultOptions
 
-    let internal traverseAParallel
-        (f: 'a -> AsyncResultOption<'b, 'e>)
-        (asyncResultOptions: 'a list)
-        : AsyncResultOption<'b list, 'e> =
-        List.foldBack (fun head tail -> (fun h t -> h :: t) <!> f head <&> tail) asyncResultOptions (singleton [])
-
-    let internal sequenceM (asyncResultOptions: AsyncResultOption<'a, 'e> list) : AsyncResultOption<'a list, 'e> =
-        traverseM id asyncResultOptions
+    let internal sequence (asyncResultOptions: AsyncResultOption<'a, 'e> list) : AsyncResultOption<'a list, 'e> =
+        mapM id asyncResultOptions
 
     let internal sequenceA (asyncResultOptions: AsyncResultOption<'a, 'e> list) : AsyncResultOption<'a list, 'e> =
-        traverseA id asyncResultOptions
+        traverse id asyncResultOptions
 
     let internal sequenceAParallel
         (asyncResultOptions: AsyncResultOption<'a, 'e> list)
         : AsyncResultOption<'a list, 'e> =
-        traverseAParallel id asyncResultOptions
-
-    let sequence (asyncResultOptions: AsyncResultOption<'a, 'e> list) : AsyncResultOption<'a list, 'e> =
-        sequenceM asyncResultOptions
-
-    let parallel' (asyncResultOptions: AsyncResultOption<'a, 'e> list) : AsyncResultOption<'a list, 'e> =
-        sequenceAParallel asyncResultOptions
+        traverseParallel id asyncResultOptions
 
     let zip
         (asyncResultOption1: AsyncResultOption<'a, 'e>)

--- a/src/AsyncResultOption.fs
+++ b/src/AsyncResultOption.fs
@@ -132,15 +132,13 @@ module AsyncResultOption =
         : AsyncResultOption<'b list, 'e> =
         traverser f (fun head tail -> cons <!> f head <&> tail) (singleton []) asyncResultOptions
 
-    let internal sequence (asyncResultOptions: AsyncResultOption<'a, 'e> list) : AsyncResultOption<'a list, 'e> =
+    let sequence (asyncResultOptions: AsyncResultOption<'a, 'e> list) : AsyncResultOption<'a list, 'e> =
         mapM id asyncResultOptions
 
-    let internal sequenceA (asyncResultOptions: AsyncResultOption<'a, 'e> list) : AsyncResultOption<'a list, 'e> =
+    let sequenceA (asyncResultOptions: AsyncResultOption<'a, 'e> list) : AsyncResultOption<'a list, 'e> =
         traverse id asyncResultOptions
 
-    let internal sequenceAParallel
-        (asyncResultOptions: AsyncResultOption<'a, 'e> list)
-        : AsyncResultOption<'a list, 'e> =
+    let sequenceAParallel (asyncResultOptions: AsyncResultOption<'a, 'e> list) : AsyncResultOption<'a list, 'e> =
         traverseParallel id asyncResultOptions
 
     let zip

--- a/src/FSharp.Prelude.fsproj
+++ b/src/FSharp.Prelude.fsproj
@@ -14,6 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="Internal.fs" />
         <Compile Include="Option.fs" />
         <Compile Include="Result.fs" />
         <Compile Include="Async.fs" />

--- a/src/Internal.fs
+++ b/src/Internal.fs
@@ -1,0 +1,4 @@
+[<AutoOpen>]
+module internal Internal
+
+let cons head tail = head :: tail

--- a/src/List.fs
+++ b/src/List.fs
@@ -44,17 +44,17 @@ module List =
 
     // AsyncResults Operations
 
-    let traverseAsyncResultM (f: 'a -> AsyncResult<'b, 'e>) (asyncResults: 'a list) : AsyncResult<'b list, 'e> =
-        AsyncResult.traverseM f asyncResults
+    let mapAsyncResultM (f: 'a -> AsyncResult<'b, 'e>) (asyncResults: 'a list) : AsyncResult<'b list, 'e> =
+        AsyncResult.mapM f asyncResults
 
-    let traverseAsyncResultA (f: 'a -> AsyncResult<'b, 'e>) (asyncResults: 'a list) : AsyncResult<'b list, 'e> =
-        AsyncResult.traverseA f asyncResults
+    let traverseAsyncResult (f: 'a -> AsyncResult<'b, 'e>) (asyncResults: 'a list) : AsyncResult<'b list, 'e> =
+        AsyncResult.traverse f asyncResults
 
-    let traverseAsyncResultAParallel (f: 'a -> AsyncResult<'b, 'e>) (asyncResults: 'a list) : AsyncResult<'b list, 'e> =
-        AsyncResult.traverseAParallel f asyncResults
+    let traverseAsyncResultParallel (f: 'a -> AsyncResult<'b, 'e>) (asyncResults: 'a list) : AsyncResult<'b list, 'e> =
+        AsyncResult.traverseParallel f asyncResults
 
-    let sequenceAsyncResultM (asyncResults: AsyncResult<'a, 'e> list) : AsyncResult<'a list, 'e> =
-        AsyncResult.sequenceM asyncResults
+    let sequenceAsyncResult (asyncResults: AsyncResult<'a, 'e> list) : AsyncResult<'a list, 'e> =
+        AsyncResult.sequence asyncResults
 
     let sequenceAsyncResultA (asyncResults: AsyncResult<'a, 'e> list) : AsyncResult<'a list, 'e> =
         AsyncResult.sequenceA asyncResults

--- a/src/List.fs
+++ b/src/List.fs
@@ -15,8 +15,7 @@ module List =
 
     let sequenceOptionA (options: Option<'a> list) : Option<'a list> = Option.sequenceA options
 
-
-    // Results Operations
+    // Results operations
 
     let mapResultM (f: 'a -> Result<'b, 'e>) (results: 'a list) : Result<'b list, 'e> = Result.mapM f results
 
@@ -26,8 +25,7 @@ module List =
 
     let sequenceResultA (results: Result<'a, 'e> list) : Result<'a list, 'e> = Result.sequenceA results
 
-
-    // Asyncs Operations
+    // Asyncs operations
 
     let mapAsyncM (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> = Async.mapM f asyncOps
 
@@ -42,7 +40,7 @@ module List =
 
     let sequenceAsyncAParallel (asyncOps: Async<'a> list) : Async<'a list> = Async.sequenceAParallel asyncOps
 
-    // AsyncResults Operations
+    // AsyncResults operations
 
     let mapAsyncResultM (f: 'a -> AsyncResult<'b, 'e>) (asyncResults: 'a list) : AsyncResult<'b list, 'e> =
         AsyncResult.mapM f asyncResults
@@ -62,8 +60,7 @@ module List =
     let sequenceAsyncResultAParallel (asyncResults: AsyncResult<'a, 'e> list) : AsyncResult<'a list, 'e> =
         AsyncResult.sequenceAParallel asyncResults
 
-
-    // AsyncOptions Operations
+    // AsyncOptions operations
 
     let traverseAsyncOptionM (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
         AsyncOption.traverseM f asyncOptions
@@ -83,8 +80,7 @@ module List =
     let sequenceAsyncOptionAParallel (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> =
         AsyncOption.sequenceAParallel asyncOptions
 
-
-    // AsyncResultOptions Operations
+    // AsyncResultOptions operations
 
     let traverseAsyncResultOptionM
         (f: 'a -> AsyncResultOption<'b, 'e>)

--- a/src/List.fs
+++ b/src/List.fs
@@ -38,7 +38,7 @@ module List =
 
     let sequenceAsyncResult (asyncResults: AsyncResult<'a, 'e> list) : AsyncResult<'a list, 'e> =
         AsyncResult.sequence asyncResults
-
+ 
     let sequenceAsyncResultA (asyncResults: AsyncResult<'a, 'e> list) : AsyncResult<'a list, 'e> =
         AsyncResult.sequenceA asyncResults
 
@@ -47,17 +47,17 @@ module List =
 
     // AsyncOptions operations
 
-    let traverseAsyncOptionM (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
-        AsyncOption.traverseM f asyncOptions
+    let mapAsyncOptionM (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
+        AsyncOption.mapM f asyncOptions
 
-    let traverseAsyncOptionA (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
-        AsyncOption.traverseA f asyncOptions
+    let traverseAsyncOption (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
+        AsyncOption.traverse f asyncOptions
 
-    let traverseAsyncOptionAParallel (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
-        AsyncOption.traverseAParallel f asyncOptions
+    let traverseAsyncOptionParallel (f: 'a -> AsyncOption<'b>) (asyncOptions: 'a list) : AsyncOption<'b list> =
+        AsyncOption.traverseParallel f asyncOptions
 
-    let sequenceAsyncOptionM (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> =
-        AsyncOption.sequenceM asyncOptions
+    let sequenceAsyncOption (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> =
+        AsyncOption.sequence asyncOptions
 
     let sequenceAsyncOptionA (asyncOptions: AsyncOption<'a> list) : AsyncOption<'a list> =
         AsyncOption.sequenceA asyncOptions

--- a/src/List.fs
+++ b/src/List.fs
@@ -25,21 +25,6 @@ module List =
 
     let sequenceResultA (results: Result<'a, 'e> list) : Result<'a list, 'e> = Result.sequenceA results
 
-    // Asyncs operations
-
-    let mapAsyncM (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> = Async.mapM f asyncOps
-
-    let traverseAsync (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> = Async.traverse f asyncOps
-
-    let traverseAsyncParallel (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> =
-        Async.traverseParallel f asyncOps
-
-    let sequenceAsync (asyncOps: Async<'a> list) : Async<'a list> = Async.sequence asyncOps
-
-    let sequenceAsyncA (asyncOps: Async<'a> list) : Async<'a list> = Async.sequenceA asyncOps
-
-    let sequenceAsyncAParallel (asyncOps: Async<'a> list) : Async<'a list> = Async.sequenceAParallel asyncOps
-
     // AsyncResults operations
 
     let mapAsyncResultM (f: 'a -> AsyncResult<'b, 'e>) (asyncResults: 'a list) : AsyncResult<'b list, 'e> =

--- a/src/List.fs
+++ b/src/List.fs
@@ -67,28 +67,28 @@ module List =
 
     // AsyncResultOptions operations
 
-    let traverseAsyncResultOptionM
+    let mapAsyncResultOptionM
         (f: 'a -> AsyncResultOption<'b, 'e>)
         (asyncResultOptions: 'a list)
         : AsyncResultOption<'b list, 'e> =
-        AsyncResultOption.traverseM f asyncResultOptions
+        AsyncResultOption.mapM f asyncResultOptions
 
-    let traverseAsyncResultOptionA
+    let traverseAsyncResultOption
         (f: 'a -> AsyncResultOption<'b, 'e>)
         (asyncResultOptions: 'a list)
         : AsyncResultOption<'b list, 'e> =
-        AsyncResultOption.traverseA f asyncResultOptions
+        AsyncResultOption.traverse f asyncResultOptions
 
-    let traverseAsyncResultOptionAParallel
+    let traverseAsyncResultOptionParallel
         (f: 'a -> AsyncResultOption<'b, 'e>)
         (asyncResultOptions: 'a list)
-        : AsyncResultOption<'b list, 'e> =
-        AsyncResultOption.traverseAParallel f asyncResultOptions
+        : AsyncResultOption<'b list, 'e> = 
+        AsyncResultOption.traverseParallel f asyncResultOptions
 
-    let sequenceAsyncResultOptionM
+    let sequenceAsyncResultOption
         (asyncResultOptions: AsyncResultOption<'a, 'e> list)
         : AsyncResultOption<'a list, 'e> =
-        AsyncResultOption.sequenceM asyncResultOptions
+        AsyncResultOption.sequence asyncResultOptions
 
     let sequenceAsyncResultOptionA
         (asyncResultOptions: AsyncResultOption<'a, 'e> list)

--- a/src/List.fs
+++ b/src/List.fs
@@ -7,13 +7,13 @@ module List =
 
     // Options operations
 
-    let traverseOptionM (f: 'a -> Option<'b>) (options: 'a list) : Option<'b list> = Option.traverseM f options
+    let mapOptionM (f: 'a -> Option<'b>) (options: 'a list) : Option<'b list> = Option.mapM f options
 
-    let traverseOptionA (f: 'a -> Option<'b>) (options: 'a list) : Option<'b list> = Option.traverseA f options
+    let traverseOption (f: 'a -> Option<'b>) (options: 'a list) : Option<'b list> = Option.traverse f options
 
-    let sequenceOptionM (options: Option<'a> list) : Option<'a list> = Option.sequenceM options
+    let sequenceOption (options: Option<'a> list) : Option<'a list> = Option.sequence options
 
-    let sequenceOptionA (options: Option<'a> list) : Option<'a list> = Option.traverseA id options
+    let sequenceOptionA (options: Option<'a> list) : Option<'a list> = Option.sequenceA options
 
 
     // Results Operations

--- a/src/List.fs
+++ b/src/List.fs
@@ -38,7 +38,7 @@ module List =
 
     let sequenceAsyncResult (asyncResults: AsyncResult<'a, 'e> list) : AsyncResult<'a list, 'e> =
         AsyncResult.sequence asyncResults
- 
+
     let sequenceAsyncResultA (asyncResults: AsyncResult<'a, 'e> list) : AsyncResult<'a list, 'e> =
         AsyncResult.sequenceA asyncResults
 
@@ -82,7 +82,7 @@ module List =
     let traverseAsyncResultOptionParallel
         (f: 'a -> AsyncResultOption<'b, 'e>)
         (asyncResultOptions: 'a list)
-        : AsyncResultOption<'b list, 'e> = 
+        : AsyncResultOption<'b list, 'e> =
         AsyncResultOption.traverseParallel f asyncResultOptions
 
     let sequenceAsyncResultOption

--- a/src/List.fs
+++ b/src/List.fs
@@ -3,7 +3,7 @@ namespace FSharp.Prelude
 [<RequireQualifiedAccess>]
 module List =
 
-    let cons head tail = head :: tail
+    let cons = cons
 
     // Options operations
 
@@ -18,11 +18,11 @@ module List =
 
     // Results Operations
 
-    let traverseResultM (f: 'a -> Result<'b, 'e>) (results: 'a list) : Result<'b list, 'e> = Result.traverseM f results
+    let mapResultM (f: 'a -> Result<'b, 'e>) (results: 'a list) : Result<'b list, 'e> = Result.mapM f results
 
-    let traverseResultA (f: 'a -> Result<'b, 'e>) (results: 'a list) : Result<'b list, 'e> = Result.traverseA f results
+    let traverseResult (f: 'a -> Result<'b, 'e>) (results: 'a list) : Result<'b list, 'e> = Result.traverse f results
 
-    let sequenceResultM (results: Result<'a, 'e> list) : Result<'a list, 'e> = Result.sequenceM results
+    let sequenceResult (results: Result<'a, 'e> list) : Result<'a list, 'e> = Result.sequence results
 
     let sequenceResultA (results: Result<'a, 'e> list) : Result<'a list, 'e> = Result.sequenceA results
 

--- a/src/List.fs
+++ b/src/List.fs
@@ -29,14 +29,14 @@ module List =
 
     // Asyncs Operations
 
-    let traverseAsyncM (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> = Async.traverseM f asyncOps
+    let mapAsyncM (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> = Async.mapM f asyncOps
 
-    let traverseAsyncA (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> = Async.traverseA f asyncOps
+    let traverseAsync (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> = Async.traverse f asyncOps
 
-    let traverseAsyncAParallel (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> =
-        Async.traverseAParallel f asyncOps
+    let traverseAsyncParallel (f: 'a -> Async<'b>) (asyncOps: 'a list) : Async<'b list> =
+        Async.traverseParallel f asyncOps
 
-    let sequenceAsyncM (asyncOps: Async<'a> list) : Async<'a list> = Async.sequenceM asyncOps
+    let sequenceAsync (asyncOps: Async<'a> list) : Async<'a list> = Async.sequence asyncOps
 
     let sequenceAsyncA (asyncOps: Async<'a> list) : Async<'a list> = Async.sequenceA asyncOps
 

--- a/src/Option.fs
+++ b/src/Option.fs
@@ -58,9 +58,9 @@ module Option =
     let mapM (f: 'a -> Option<'b>) (options: 'a list) : Option<'b list> =
         let folder head tail =
             f head
-            >>= (fun head' ->
-                tail
-                >>= (fun tail' -> singleton <| cons head' tail'))
+            >>= fun head' ->
+                    tail
+                    >>= fun tail' -> singleton <| cons head' tail'
 
         traverser f folder (singleton []) options
 

--- a/src/Option.fs
+++ b/src/Option.fs
@@ -38,8 +38,6 @@ module Option =
 
     let andMap (option: 'a option) (f: ('a -> 'b) option) : 'b option = Option.map2 (|>) option f
 
-    let compose (f: 'a -> 'b option) (g: 'b -> 'c option) : 'a -> 'c option = f >=> g
-
     let rec private traverser f folder state xs =
         match xs with
         | [] -> List.rev <!> state

--- a/src/Option.fs
+++ b/src/Option.fs
@@ -48,7 +48,7 @@ module Option =
 
     let rec private traverser f folder state xs =
         match xs with
-        | [] -> Option.map List.rev state
+        | [] -> List.rev <!> state
         | head :: tail ->
             folder head state
             |> function

--- a/src/Option.fs
+++ b/src/Option.fs
@@ -16,12 +16,6 @@ module OptionOperators =
     /// Infix bind operator.
     let inline (>>=) (option: 'a option) (f: 'a -> 'b option) : 'b option = Option.bind f option
 
-    let inline (>=>) (f: 'a -> 'b option) (g: 'b -> 'c option) : 'a -> 'c option =
-        fun x ->
-            match f x with
-            | Some thing -> g thing
-            | None -> None
-
     /// Infix alternative operator.
     let inline (<|>) (option1: 'a option) (option2: 'a option) : 'a option =
         match option1, option2 with

--- a/src/Option.fs
+++ b/src/Option.fs
@@ -38,7 +38,7 @@ module Option =
 
     let andMap (option: 'a option) (f: ('a -> 'b) option) : 'b option = Option.map2 (|>) option f
 
-    let rec private traverser f folder state xs =
+    let rec private traverser (f: 'a -> Option<'b>) folder state xs =
         match xs with
         | [] -> List.rev <!> state
         | head :: tail ->
@@ -77,7 +77,7 @@ module Option =
         | Choice2Of2 _ -> None
 
     /// Creates a safe version of the supplied function, returning None instead of throwing an exception.
-    let ofThrowable (f: 'a -> 'b) a : 'b option =
+    let ofThrowable (f: 'a -> 'b) (a: 'a) : 'b option =
         try
             Some(f a)
         with _ -> None

--- a/src/Result.fs
+++ b/src/Result.fs
@@ -62,9 +62,9 @@ module Result =
     let mapM (f: 'a -> Result<'b, 'e>) (results: 'a list) : Result<'b list, 'e> =
         let folder head tail =
             f head
-            >>= (fun head' ->
-                tail
-                >>= (fun tail' -> singleton <| cons head' tail'))
+            >>= fun head' ->
+                    tail
+                    >>= fun tail' -> singleton <| cons head' tail'
 
         traverser f folder (singleton []) results
 

--- a/src/Result.fs
+++ b/src/Result.fs
@@ -42,7 +42,7 @@ module Result =
     let bimap (f: 'a -> 'b) (g: 'e1 -> 'e2) (result: Result<'a, 'e1>) : Result<'b, 'e2> =
         (Result.map f >> Result.mapError g) result
 
-    let rec private traverser f folder state xs =
+    let rec private traverser (f: 'a -> Result<'b, 'e>) folder state xs =
         match xs with
         | [] -> List.rev <!> state
         | head :: tail ->
@@ -81,7 +81,7 @@ module Result =
         | Choice2Of2 right -> Error right
 
     /// Creates a safe version of the supplied function, returning Error(exn) instead of throwing an exception.
-    let ofThrowable (f: 'a -> 'b) a : Result<'b, exn> =
+    let ofThrowable (f: 'a -> 'b) (a: 'a) : Result<'b, exn> =
         try
             Ok(f a)
         with exn -> Error exn

--- a/src/Result.fs
+++ b/src/Result.fs
@@ -52,7 +52,7 @@ module Result =
 
     let rec private traverser f folder state xs =
         match xs with
-        | [] -> Result.map List.rev state
+        | [] -> List.rev <!> state
         | head :: tail ->
             folder head state
             |> function

--- a/src/Result.fs
+++ b/src/Result.fs
@@ -16,12 +16,6 @@ module ResultOperators =
     /// Infix bind operator.
     let inline (>>=) (result: Result<'a, 'e>) (f: 'a -> Result<'b, 'e>) : Result<'b, 'e> = Result.bind f result
 
-    let (>=>) (f: 'a -> Result<'b, 'e>) (g: 'b -> Result<'c, 'e>) : 'a -> Result<'c, 'e> =
-        fun x ->
-            match f x with
-            | Ok ok -> g ok
-            | Error e -> Error e
-
 
 namespace FSharp.Prelude
 

--- a/src/Result.fs
+++ b/src/Result.fs
@@ -42,8 +42,6 @@ module Result =
     let bimap (f: 'a -> 'b) (g: 'e1 -> 'e2) (result: Result<'a, 'e1>) : Result<'b, 'e2> =
         (Result.map f >> Result.mapError g) result
 
-    let compose (f: 'a -> Result<'b, 'e>) (g: 'b -> Result<'c, 'e>) : 'a -> Result<'c, 'e> = f >=> g
-
     let rec private traverser f folder state xs =
         match xs with
         | [] -> List.rev <!> state

--- a/tests/AsyncResultTests.fs
+++ b/tests/AsyncResultTests.fs
@@ -90,6 +90,62 @@ let sequenceTests =
         ]
 
 [<Tests>]
+let sequenceATests =
+    testList
+        "SequenceA tests"
+        [
+            testAsync "should return values in same order as given tasks" {
+                let expected = Ok [ 1; 2; 3 ]
+
+                let input =
+                    [
+                        (AsyncResult.singleton 1)
+                        (AsyncResult.singleton 2)
+                        (AsyncResult.singleton 3)
+                    ]
+
+                let! actual = AsyncResult.sequenceA input
+                Expect.equal actual expected "should equal"
+            }
+            testAsync "should prove example" {
+                let fetchUser : int -> AsyncResult<int, 'err> = AsyncResult.singleton
+
+                let userIds = [ 1; 2; 3 ]
+                let expected = Ok userIds
+
+                let! actual =
+                    userIds
+                    |> List.map fetchUser
+                    |> AsyncResult.sequenceA
+
+                Expect.equal actual expected "should equal"
+            }
+            testAsync "should execute async task in sequence" {
+                let mutable orderRun = []
+
+                let dummyAsync : int -> AsyncResult<int, string> =
+                    fun i ->
+                        AsyncResult.ofResult (Ok i)
+                        |> AsyncResult.map
+                            (fun j ->
+                                orderRun <- List.append orderRun [ j ]
+                                j)
+
+                let input =
+                    [
+                        Async.Sleep 100
+                        |> Async.bind (fun _ -> dummyAsync 1)
+                        (dummyAsync 2)
+                        (dummyAsync 3)
+                    ]
+
+                let expectedOkValue = [ 1; 2; 3 ]
+                let! _actual = AsyncResult.sequenceA input
+                Expect.equal orderRun expectedOkValue "Should be run in same order"
+            }
+        ]
+
+[<Tests>]
 let traverseTests =
     testList
         "Traverse tests"
@@ -145,6 +201,66 @@ let traverseTests =
                 let expected = Ok input
 
                 let! actual = AsyncResult.traverse delay input
+                Expect.equal actual expected "Should be run in same order"
+            }
+        ]
+
+[<Tests>]
+let mapMTests =
+    testList
+        "MapM tests"
+        [
+            testAsync "should return values in same order as given tasks" {
+                let input = [ 1; 2; 3 ]
+                let expected = Ok [ 1; 2; 3 ]
+
+                let! actual = AsyncResult.mapM AsyncResult.singleton input
+                Expect.equal actual expected "should equal"
+            }
+            testAsync "should return map the AsyncResult values" {
+                let transformer = ((+) 10) >> AsyncResult.singleton
+
+                let input = [ 1; 2; 3 ]
+                let expected = Ok [ 11; 12; 13 ]
+
+                let! actual = AsyncResult.mapM transformer input
+                Expect.equal actual expected "should equal"
+            }
+            testAsync "should make an early return if there is an Error" {
+                let mutable currentItem = 0
+
+                let transformer x =
+                    currentItem <- x
+
+                    if x = 2 then
+                        AsyncResult.ofResult (Error "Skip next")
+                    else
+                        AsyncResult.singleton x
+
+                let! _ = AsyncResult.mapM transformer [ 1; 2; 3 ]
+
+                Expect.equal currentItem 2 "should equal"
+            }
+            testAsync "should prove example" {
+                let fetchUser : int -> AsyncResult<int, 'err> = AsyncResult.singleton
+
+                let userIds = [ 1; 2; 3 ]
+
+                let expected = Ok userIds
+
+                let! actual = AsyncResult.mapM fetchUser userIds
+
+                Expect.equal actual expected "should equal"
+            }
+            testAsync "should execute async task in sequence" {
+                let delay x =
+                    Async.Sleep(x * 100)
+                    |> Async.bind (fun _ -> AsyncResult.singleton x)
+
+                let input = [ 0; 14; 1; 3 ]
+                let expected = Ok input
+
+                let! actual = AsyncResult.mapM delay input
                 Expect.equal actual expected "Should be run in same order"
             }
         ]

--- a/tests/AsyncResultTests.fs
+++ b/tests/AsyncResultTests.fs
@@ -1,4 +1,4 @@
-module Tests
+module FSharp.Prelude.Tests.AsyncResultTests
 
 open Expecto
 open FSharp.Prelude

--- a/tests/AsyncResultTests.fs
+++ b/tests/AsyncResultTests.fs
@@ -1,21 +1,467 @@
 module FSharp.Prelude.Tests.AsyncResultTests
 
-open Expecto
+open System.Threading
+open System.Threading.Tasks
 open FSharp.Prelude
+open Expecto
 
 [<Tests>]
-let tests =
-  testList "AsyncResult tests" [
-    
-    testAsync "Should sequence" {
-       let sample = [1 ; 2; 3]
-       
-       let expected = Ok sample
-       
-       let input = List.map AsyncResult.singleton sample
-       
-       let! actual = AsyncResult.sequence input
-       
-       Expect.equal actual expected "Should equal"
-    }
-  ]
+let creationTests =
+    let testSingleton text value =
+        testAsync text {
+            let! actual = AsyncResult.singleton value
+            let expected = Ok value
+
+            Expect.equal actual expected "should equal"
+        }
+
+    testList
+        "Test creating new AsyncResult"
+        [
+            testList
+                "singleton"
+                [
+                    testSingleton "should create an Ok AsyncResult given a string" "test"
+
+                    testSingleton "should create an Ok AsyncResult given an int" 4
+
+                    testSingleton "should create an Ok AsyncResult given a bool" true
+
+                    testSingleton "should nest Ok in a Ok AsyncResult" (Ok 1)
+
+                    testSingleton "should nest Error in a Ok AsyncResult" (Error "This is in an Ok")
+                ]
+        ]
+
+[<Tests>]
+let sequenceTests =
+    testList
+        "Sequence tests"
+        [
+            testAsync "should return values in same order as given tasks" {
+                let expected = Ok [ 1; 2; 3 ]
+
+                let input =
+                    [
+                        (AsyncResult.singleton 1)
+                        (AsyncResult.singleton 2)
+                        (AsyncResult.singleton 3)
+                    ]
+
+                let! actual = AsyncResult.sequence input
+                Expect.equal actual expected "should equal"
+            }
+            testAsync "should prove example" {
+                let fetchUser : int -> AsyncResult<int, 'err> = AsyncResult.singleton
+
+                let userIds = [ 1; 2; 3 ]
+                let expected = Ok userIds
+
+                let! actual =
+                    userIds
+                    |> List.map fetchUser
+                    |> AsyncResult.sequence
+
+                Expect.equal actual expected "should equal"
+            }
+            testAsync "should execute async task in sequence" {
+                let mutable orderRun = []
+
+                let dummyAsync : int -> AsyncResult<int, string> =
+                    fun i ->
+                        AsyncResult.ofResult (Ok i)
+                        |> AsyncResult.map
+                            (fun j ->
+                                orderRun <- List.append orderRun [ j ]
+                                j)
+
+                let input =
+                    [
+                        Async.Sleep 100
+                        |> Async.bind (fun _ -> dummyAsync 1)
+                        (dummyAsync 2)
+                        (dummyAsync 3)
+                    ]
+
+                let expectedOkValue = [ 1; 2; 3 ]
+                let! _actual = AsyncResult.sequence input
+                Expect.equal orderRun expectedOkValue "Should be run in same order"
+            }
+        ]
+
+[<Tests>]
+let traverseTests =
+    testList
+        "Traverse tests"
+        [
+            testAsync "should return values in same order as given tasks" {
+                let input = [ 1; 2; 3 ]
+                let expected = Ok [ 1; 2; 3 ]
+
+                let! actual = AsyncResult.traverse AsyncResult.singleton input
+                Expect.equal actual expected "should equal"
+            }
+            testAsync "should return map the AsyncResult values" {
+                let transformer = ((+) 10) >> AsyncResult.singleton
+
+                let input = [ 1; 2; 3 ]
+                let expected = Ok [ 11; 12; 13 ]
+
+                let! actual = AsyncResult.traverse transformer input
+                Expect.equal actual expected "should equal"
+            }
+            testAsync "should make an early return if there is an Error" {
+                let mutable currentItem = 0
+
+                let transformer x =
+                    currentItem <- x
+
+                    if x = 2 then
+                        AsyncResult.ofResult (Error "Skip next")
+                    else
+                        AsyncResult.singleton x
+
+                let! _ = AsyncResult.traverse transformer [ 1; 2; 3 ]
+
+                Expect.equal currentItem 2 "should equal"
+            }
+            testAsync "should prove example" {
+                let fetchUser : int -> AsyncResult<int, 'err> = AsyncResult.singleton
+
+                let userIds = [ 1; 2; 3 ]
+
+                let expected = Ok userIds
+
+                let! actual = AsyncResult.traverse fetchUser userIds
+
+                Expect.equal actual expected "should equal"
+            }
+            testAsync "should execute async task in sequence" {
+                let delay x =
+                    Async.Sleep(x * 100)
+                    |> Async.bind (fun _ -> AsyncResult.singleton x)
+
+                let input = [ 0; 14; 1; 3 ]
+                let expected = Ok input
+
+                let! actual = AsyncResult.traverse delay input
+                Expect.equal actual expected "Should be run in same order"
+            }
+        ]
+
+[<Tests>]
+let taskTests =
+    testList
+        "Task tests"
+        [
+            testList
+                "ofUnitTask"
+                [
+                    testAsync "should convert from Task to AsyncResult" {
+                        let source = new CancellationTokenSource()
+                        let input : (unit -> Task) = fun () -> Task.Delay(0, source.Token)
+
+                        let expectedValue = Ok()
+
+                        let! actual = AsyncResult.ofUnitTask input
+
+                        Expect.equal actual expectedValue "Should be equal"
+                    }
+                ]
+            testList
+                "ofTask"
+                [
+                    testAsync "should convert from Task<string> to AsyncResult" {
+                        let input =
+                            fun () -> Async.singleton "Hello" |> Async.StartAsTask
+
+                        let expectedValue = Ok "Hello"
+
+                        let! actual = AsyncResult.ofTask input
+
+                        Expect.equal actual expectedValue "Should be equal"
+                    }
+                ]
+        ]
+
+[<Tests>]
+let applyTest =
+    testList
+        "Test apply"
+        [
+            testAsync "should apply the value to function" {
+                let xA = AsyncResult.singleton 42
+                let fA = AsyncResult.singleton ((+) 10)
+
+                let! actual = AsyncResult.apply fA xA
+
+                let expectedValue = Ok 52
+
+                Expect.equal actual expectedValue "Should be equal"
+            }
+
+            testAsync "should apply the value to all functions" {
+                let xA = AsyncResult.singleton 42
+                let fA1 = AsyncResult.singleton ((+) 10)
+                let fA2 = AsyncResult.singleton (fun x -> x / 2)
+
+                let! actual =
+                    xA
+                    |> AsyncResult.apply fA1
+                    |> AsyncResult.apply fA2
+                    |> AsyncResult.apply fA2
+
+                let expectedValue = Ok 13
+
+                Expect.equal actual expectedValue "Should be equal"
+            }
+
+            testAsync "should follow the law of Identity (apply id v = v)" {
+                let v = AsyncResult.singleton 42
+                let f = AsyncResult.singleton id
+
+                let! actual = AsyncResult.apply f v
+                let! expectedValue = v
+
+                Expect.equal actual expectedValue "Should be equal"
+            }
+            testAsync "should follow the law of Homomorphism (apply fA xA = AR.of (f x)" {
+                let x = 42
+                let f = ((+) 10)
+
+                let xA = AsyncResult.singleton x
+                let fA = AsyncResult.singleton f
+
+                let! actual = AsyncResult.apply fA xA
+                let! expectedValue = AsyncResult.singleton (f x)
+
+                Expect.equal actual expectedValue "Should be equal"
+            }
+            testAsync "should follow the law of Composition (xA |> apply fA1 |> apply fA2 = apply fA1 (apply fA2 xA))" {
+                let fA1 = AsyncResult.singleton ((+) 10)
+                let fA2 = AsyncResult.singleton ((-) 2)
+                let xA = AsyncResult.singleton 42
+
+                let! actual =
+                    xA
+                    |> AsyncResult.apply fA2
+                    |> AsyncResult.apply fA1
+
+                let! expectedValue = AsyncResult.apply fA1 (AsyncResult.apply fA2 xA)
+
+                Expect.equal actual expectedValue "Should be equal"
+            }
+            testAsync "should wrap the Error value and result in an Error" {
+                let fA1 = AsyncResult.singleton ((+) 10)
+                let fA2 = AsyncResult.ofResult (Error 2)
+                let xA = AsyncResult.singleton 42
+
+                let! actual =
+                    xA
+                    |> AsyncResult.apply fA2
+                    |> AsyncResult.apply fA1
+
+                let expectedValue = Error 2
+
+                Expect.equal actual expectedValue "Should be equal"
+            }
+
+            testAsync "should wrap the first Error value and result in an Error" {
+                let fA1 = AsyncResult.ofResult (Error 1)
+                let fA2 = AsyncResult.ofResult (Error 2)
+                let xA = AsyncResult.singleton 42
+
+                let! actual =
+                    xA
+                    |> AsyncResult.apply fA2
+                    |> AsyncResult.apply fA1
+
+                let expectedValue = Error 1
+
+                Expect.equal actual expectedValue "Should be equal"
+            }
+
+            testAsync "should result in an Error if the value is an Error" {
+                let fA1 = AsyncResult.singleton ((+) 10)
+                let fA2 = AsyncResult.singleton ((-) 2)
+                let xA = AsyncResult.ofResult (Error 42)
+
+                let! actual =
+                    xA
+                    |> AsyncResult.apply fA2
+                    |> AsyncResult.apply fA1
+
+                let expectedValue = Error 42
+
+                Expect.equal actual expectedValue "Should be equal"
+            }
+
+        ]
+
+[<Tests>]
+let mapTests =
+    testList
+        "Test map functions"
+        [
+            testList
+                "map"
+                [
+                    testAsync "should change the value in an AsyncResult" {
+                        let input = AsyncResult.singleton 3
+
+                        let expectedValue = Ok 4
+
+                        let! actual = AsyncResult.map ((+) 1) input
+
+                        Expect.equal actual expectedValue "Should be equal"
+                    }
+                    testAsync "should NOT change the value in an Error AsyncResult" {
+                        let input = AsyncResult.ofResult (Error 3)
+
+                        let expectedValue = Error 3
+
+                        let! actual = AsyncResult.map ((+) 1) input
+
+                        Expect.equal actual expectedValue "Should be equal"
+                    }
+                ]
+
+            testList
+                "map2"
+                [
+                    testAsync "should map over the value from two AsyncResult" {
+                        let input1 = AsyncResult.singleton 3
+                        let input2 = AsyncResult.singleton 7
+
+                        let expectedValue = Ok 10
+
+                        let! actual = AsyncResult.map2 (+) input1 input2
+
+                        Expect.equal actual expectedValue "Should be equal"
+                    }
+
+                    testAsync "should fail if the first AsyncResult is an error" {
+                        let input1 = AsyncResult.ofResult (Error "Not Ok")
+                        let input2 = AsyncResult.singleton 3
+
+                        let expectedValue = Error "Not Ok"
+
+                        let! actual = AsyncResult.map2 (+) input1 input2
+
+                        Expect.equal actual expectedValue "Should be equal"
+                    }
+
+                    testAsync "should fail if the second AsyncResult is an error" {
+                        let input1 = AsyncResult.singleton 3
+
+                        let input2 =
+                            AsyncResult.ofResult (Error "Not Ok either")
+
+                        let expectedValue = Error "Not Ok either"
+
+                        let! actual = AsyncResult.map2 (+) input1 input2
+
+                        Expect.equal actual expectedValue "Should be equal"
+                    }
+
+                    testAsync "should pass arguments in order" {
+                        let input1 = AsyncResult.singleton 3
+                        let input2 = AsyncResult.singleton 7
+
+                        let expected = Ok(3, 7)
+
+                        let! actual = AsyncResult.map2 (fun a b -> (a, b)) input1 input2
+
+                        Expect.equal actual expected "Should be equal"
+
+                    }
+                ]
+
+            testList
+                "andMap"
+                [
+                    testAsync "should apply AsyncResult value to AsyncResult function" {
+                        let fA = AsyncResult.singleton ((+) 10)
+                        let xA = AsyncResult.singleton 20
+
+                        let expected = Ok 30
+
+                        let! actual = AsyncResult.andMap xA fA
+
+                        Expect.equal actual expected "Should be equal"
+                    }
+                    testAsync "should be pipeable" {
+                        let fA =
+                            AsyncResult.singleton (fun a b c -> a + b + c)
+
+                        let xA = AsyncResult.singleton 10
+                        let yA = AsyncResult.singleton 20
+                        let zA = AsyncResult.singleton 30
+
+                        let expected = Ok 60
+
+                        let! actual =
+                            fA
+                            |> AsyncResult.andMap xA
+                            |> AsyncResult.andMap yA
+                            |> AsyncResult.andMap zA
+
+                        Expect.equal actual expected "Should be equal"
+                    }
+                    testAsync "should fail if there is an Error" {
+                        let fA =
+                            AsyncResult.singleton (fun a b c -> a + b + c)
+
+                        let xA = AsyncResult.singleton 10
+
+                        let yA =
+                            AsyncResult.ofResult (Error "Oh no an error")
+
+                        let zA = AsyncResult.singleton 30
+
+                        let expected = Error "Oh no an error"
+
+                        let! actual =
+                            fA
+                            |> AsyncResult.andMap xA
+                            |> AsyncResult.andMap yA
+                            |> AsyncResult.andMap zA
+
+                        Expect.equal actual expected "Should be equal"
+                    }
+                ]
+        ]
+
+[<Tests>]
+let bindTests =
+    testList
+        "Test bind functions"
+        [
+            testList
+                "bind"
+                [
+                    testAsync "should change the value in an AsyncResult" {
+                        let input = AsyncResult.singleton 3
+
+                        let f = ((+) 1 >> AsyncResult.singleton)
+
+                        let expectedValue = Ok 4
+
+                        let! actual = AsyncResult.bind f input
+
+                        Expect.equal actual expectedValue "Should be equal"
+                    }
+
+                    testAsync "should NOT change the value in an Error AsyncResult" {
+                        let input = AsyncResult.ofResult (Error 3)
+
+                        let f = (+) 1 >> Ok >> AsyncResult.ofResult
+
+                        let expectedValue = Error 3
+
+                        let! actual = AsyncResult.bind f input
+
+                        Expect.equal actual expectedValue "Should be equal"
+                    }
+                ]
+        ]

--- a/tests/FSharp.Prelude.Tests.fsproj
+++ b/tests/FSharp.Prelude.Tests.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="AsyncResultTests.fs" />
+    <Compile Include="ResultTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/tests/ResultTests.fs
+++ b/tests/ResultTests.fs
@@ -1,0 +1,22 @@
+module FSharp.Prelude.Tests.ResultTests
+
+open Expecto
+open FSharp.Prelude
+
+let test1 =
+    test "Should sequence" {
+        let sample = [ 1; 2; 3 ]
+
+        let expected = Ok sample
+
+        let input = List.map Result.singleton sample
+
+        let actual = Result.sequence input
+
+        Expect.equal actual expected "Should equal"
+    }
+
+
+
+[<Tests>]
+let tests = testList "Result tests" [ test1 ]

--- a/tests/ResultTests.fs
+++ b/tests/ResultTests.fs
@@ -16,7 +16,5 @@ let test1 =
         Expect.equal actual expected "Should equal"
     }
 
-
-
 [<Tests>]
 let tests = testList "Result tests" [ test1 ]


### PR DESCRIPTION
- Remove `traverse` and `sequence` function from `Async` because it already has it's own version of them
- Remove `parallel'` from `AsyncResult` `AsyncOption` `AsyncResultOption`
- Remove kleisli operator and `compose` function
- Rename `traverseM` to `mapM`
- Rename `traverseA` to `traverse`
- Rename `travseParallelA` to `traverseParallel`
- Rename `sequenceM` to `sequence`
- Use a tail recursive version of `traverse` and `sequence` to support early termination