### PR TITLE
One namespace to rule them all!

### DIFF
--- a/src/ErrorHandling/AsyncOption.fs
+++ b/src/ErrorHandling/AsyncOption.fs
@@ -1,6 +1,6 @@
 namespace Prelude.Operators.AsyncOption
 
-open Prelude.Extensions
+open Prelude
 
 [<AutoOpen>]
 module AsyncOptionOperators =
@@ -33,9 +33,8 @@ module AsyncOptionOperators =
         Async.map2 Option.alternative asyncOption1 asyncOption2
 
 
-namespace Prelude.ErrorHandling
+namespace Prelude
 
-open Prelude.Extensions
 open Prelude.Operators.AsyncOption
 open System.Threading.Tasks
 

--- a/src/ErrorHandling/AsyncResult.fs
+++ b/src/ErrorHandling/AsyncResult.fs
@@ -1,6 +1,6 @@
 namespace Prelude.Operators.AsyncResult
 
-open Prelude.Extensions
+open Prelude
 
 [<AutoOpen>]
 module AsyncResultOperators =
@@ -34,9 +34,8 @@ module AsyncResultOperators =
             asyncResult
 
 
-namespace Prelude.ErrorHandling
+namespace Prelude
 
-open Prelude.Extensions
 open Prelude.Operators.AsyncResult
 open System.Threading.Tasks
 

--- a/src/ErrorHandling/AsyncResultOption.fs
+++ b/src/ErrorHandling/AsyncResultOption.fs
@@ -1,7 +1,6 @@
 namespace Prelude.Operators.AsyncResultOption
 
-open Prelude.ErrorHandling
-open Prelude.Extensions
+open Prelude
 
 [<AutoOpen>]
 module AsyncResultOptionOperators =
@@ -43,9 +42,8 @@ module AsyncResultOptionOperators =
         AsyncResult.map2 Option.alternative asyncOption1 asyncOption2
 
 
-namespace Prelude.ErrorHandling
+namespace Prelude
 
-open Prelude.Extensions
 open Prelude.Operators.AsyncResultOption
 open System.Threading.Tasks
 

--- a/src/Extensions/Async.fs
+++ b/src/Extensions/Async.fs
@@ -32,7 +32,7 @@ module AsyncOperators =
     let inline (>>=) (asyncOp: Async<'a>) (f: 'a -> Async<'b>) : Async<'b> = async.Bind(asyncOp, f)
 
 
-namespace Prelude.Extensions
+namespace Prelude
 
 open Prelude.Operators.Async
 

--- a/src/Extensions/List.fs
+++ b/src/Extensions/List.fs
@@ -1,6 +1,6 @@
 namespace Prelude.Extensions
 
-open Prelude.ErrorHandling
+open Prelude
 
 [<RequireQualifiedAccess>]
 module List =

--- a/src/Extensions/Option.fs
+++ b/src/Extensions/Option.fs
@@ -23,7 +23,7 @@ module OptionOperators =
         | left, _ -> left
 
 
-namespace Prelude.Extensions
+namespace Prelude
 
 open Prelude.Operators.Option
 

--- a/src/Extensions/Prelude.fs
+++ b/src/Extensions/Prelude.fs
@@ -1,4 +1,4 @@
-namespace Prelude.Extensions
+namespace Prelude
 
 [<AutoOpen>]
 module FunctionalExtensions =

--- a/src/Extensions/Result.fs
+++ b/src/Extensions/Result.fs
@@ -17,7 +17,7 @@ module ResultOperators =
     let inline (>>=) (result: Result<'a, 'e>) (f: 'a -> Result<'b, 'e>) : Result<'b, 'e> = Result.bind f result
 
 
-namespace Prelude.Extensions
+namespace Prelude
 
 open Prelude.Operators.Result
 

--- a/src/Extensions/String.fs
+++ b/src/Extensions/String.fs
@@ -1,4 +1,4 @@
-namespace Prelude.Extensions
+namespace Prelude
 
 [<RequireQualifiedAccess>]
 module String =

--- a/src/FDI/Reader.fs
+++ b/src/FDI/Reader.fs
@@ -13,7 +13,7 @@ module ReaderOperators =
     let inline (>>=) (reader: 'r -> 'a) (f: 'a -> 'r -> 'b) : 'r -> 'b = fun r -> f (reader r) r
 
 
-namespace Prelude.FDI
+namespace Prelude
 
 open Prelude.Operators.Reader
 

--- a/src/FDI/ReaderAsyncResult.fs
+++ b/src/FDI/ReaderAsyncResult.fs
@@ -1,6 +1,6 @@
 namespace Prelude.Operators.ReaderResult
 
-open Prelude.ErrorHandling
+open Prelude
 
 [<AutoOpen>]
 module ResultAsyncReaderOperators =
@@ -23,9 +23,8 @@ module ResultAsyncReaderOperators =
         : 'r -> Async<Result<'b, 'e>> =
         fun r -> AsyncResult.bind (fun a -> f a r) (rar r)
 
-namespace Prelude.FDI
+namespace Prelude
 
-open Prelude.ErrorHandling
 open Prelude.Operators.ReaderResult
 open System.Threading.Tasks
 

--- a/src/FDI/ReaderResult.fs
+++ b/src/FDI/ReaderResult.fs
@@ -1,6 +1,6 @@
 namespace Prelude.Operators.ReaderResult
 
-open Prelude.Extensions
+open Prelude
 
 [<AutoOpen>]
 module ResultReaderOperators =
@@ -17,9 +17,8 @@ module ResultReaderOperators =
         fun r -> Result.bind (fun a -> f a r) (rr r)
 
 
-namespace Prelude.FDI
+namespace Prelude
 
-open Prelude.Extensions
 open Prelude.Operators.ReaderResult
 
 type ReaderResult<'r, 'a, 'e> = 'r -> Result<'a, 'e>

--- a/tests/ErrorHandling/AsyncResultTests.fs
+++ b/tests/ErrorHandling/AsyncResultTests.fs
@@ -3,7 +3,7 @@ module FSharp.Prelude.Tests.AsyncResultTests
 open System.Threading
 open System.Threading.Tasks
 open Prelude.Extensions
-open Prelude.ErrorHandling
+open Prelude
 open Expecto
 
 [<Tests>]

--- a/tests/ErrorHandling/ResultTests.fs
+++ b/tests/ErrorHandling/ResultTests.fs
@@ -1,7 +1,7 @@
 module FSharp.Prelude.Tests.ResultTests
 
 open Expecto
-open Prelude.Extensions
+open Prelude
 
 let test1 =
     test "Should sequence" {

--- a/tests/FDI/ReaderAsyncResult.fs
+++ b/tests/FDI/ReaderAsyncResult.fs
@@ -2,8 +2,7 @@ module Prelude.Tests.DependencyManagement.ReaderAsyncResult
 
 open Expecto
 open Expecto.Flip
-open Prelude.FDI
-open Prelude.Extensions
+open Prelude
 
 type Env1 = { apiKey: string; db: string }
 type Env2 = { greeting: string }


### PR DESCRIPTION
After separating the files into categories, namespace separation followed. In theory this is nice, but in practice it was hard to remember what was where so I decided to put everything under the namespace `Prelude`. 